### PR TITLE
Add a way to force reinstalling dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ The following variables can/must be set in the inventory:
 * `app_repo`: Path to the application repository.
   * If the repo is private, you should set `app_ssh_key` to a private key that is authorized to read the repo (use the SSH URL for the repo), or set `app_ssh_key_path` to the path to the proper file on the host.
 * `app_tag`: Tag or branch of the `app_repo` to checkout.
-* `python_version`: Python version to use.
+* `python_version`: Python version to use. (If changed, set `conda_force_recreate` to true the next time the role is executed).
 * `conda_version`: Conda version to use. See the list [here](https://repo.anaconda.com/miniconda). Put the part of the name that's in between `Miniconda3` and `.sh`, e.g. `latest-Linux-aarch64` or `py311_23.10.0-1-Linux-x86_64`. Make sure it's the right architecture.
+* `conda_force_recreate`: If true, any existing conda environment will be wiped out and dependencies will be reinstalled from scratch. You have to set this to true when changing the Python version.
 
 
 ## Defining a service

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ app_code_dir: "{{ app_dir }}/code"
 
 conda_isolate: false
 conda_base: "{{ app_dir if conda_isolate else global_app_root }}/miniconda3"
+conda_force_recreate: false
 
 app_config_dir: "{{ app_dir }}/config"
 app_config: "{{ app_config_dir }}/config.yaml"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,6 +27,11 @@
     accept_hostkey: yes
     key_file: "{{ app_ssh_key_path }}"
 
+- name: Remove existing conda environment if requested
+  ansible.builtin.command:
+    cmd: "{{ conda_base }}/bin/conda remove --name {{ app_name }} --all --force -y"
+  when: conda_force_recreate
+
 - name: Create a conda environment
   ansible.builtin.command:
     cmd: "{{ conda_base }}/bin/conda create --name {{ app_name }} python={{ python_version }} --force -y"


### PR DESCRIPTION
Adds the `conda_force_recreate` variable, if it is true the existing conda environment will be removed and then recreated, and the dependencies will be installed from scratch.

When changing `python_version`, you will have to set it to true to force the environment to be recreated. Also if for some reason you need to wipe out old dependencies that are not needed anymore.

Also, when pip installing from a git repo, pip checks the version in the pyproject or setup file and only seems to reinstall if it's different from the current one. That can be annoying if there's a bug in the revision you installed and you need to revert to a state that technically has the same version number. This also solves that.
