### PR TITLE
Let uv run handle environment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By default, the pyservice role will create a user, and the following hierarchy:
 # Root for all pyservice-installed applications, owner is root
 /applications        # Variable: {{ global_app_root }}
   # uv binary is installed here
-  /bin               # Variable: {{ uv_location }}
+  /uv                # Variable: {{ uv_location }}
   # App directory; owner is the the app user
   /APP_NAME          # Variable: {{ app_root }}
     # Application code and configuration
@@ -35,6 +35,9 @@ By default, the pyservice role will create a user, and the following hierarchy:
         config.yaml  # Variable: {{ app_config }}
     # Application data (anything that must be backed up)
     /data            # Variable: {{ app_code_dir }}
+    # Virtual environment
+    /uv
+      /venv
 /etc
   /systemd
     /system

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,8 @@ app_code_dir: "{{ app_dir }}/code"
 uv_isolate: false
 uv_version: "0.5.1"
 uv_location: "{{ app_dir if uv_isolate else global_app_root }}/uv"
-uv_bin: "env VIRTUAL_ENV={{ app_code_dir }}/.venv UV_PYTHON_INSTALL_DIR={{ uv_location }}/python UV_CACHE_DIR={{ uv_location }}/cache {{ uv_location }}/uv"
+uv_local: "{{ app_dir }}/uv"
+uv_bin: "env UV_PROJECT_ENVIRONMENT={{ uv_local }}/venv UV_PYTHON_INSTALL_DIR={{ uv_local }}/python UV_CACHE_DIR={{ uv_local }}/cache {{ uv_location }}/uv"
 
 app_config_dir: "{{ app_dir }}/config"
 app_config: "{{ app_config_dir }}/config.yaml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,9 +18,6 @@ app_code_dir: "{{ app_dir }}/code"
 
 uv_isolate: false
 uv_version: "0.5.1"
-uv_location: "{{ app_dir if uv_isolate else global_app_root }}/uv"
-uv_local: "{{ app_dir }}/uv"
-uv_bin: "env UV_PROJECT_ENVIRONMENT={{ uv_local }}/venv UV_PYTHON_INSTALL_DIR={{ uv_local }}/python UV_CACHE_DIR={{ uv_local }}/cache {{ uv_location }}/uv"
 
 app_config_dir: "{{ app_dir }}/config"
 app_config: "{{ app_config_dir }}/config.yaml"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,3 @@
     version: "{{ app_tag }}"
     accept_hostkey: yes
     key_file: "{{ app_ssh_key_path }}"
-
-- name: Sync dependencies
-  ansible.builtin.command:
-    cmd: "{{ uv_bin }} sync --locked --directory {{ app_code_dir }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,5 @@
 ---
+uv_location: "{{ app_dir if uv_isolate else global_app_root }}/uv"
+uv_local: "{{ app_dir }}/uv"
+uv_bin: "env UV_PROJECT_ENVIRONMENT={{ uv_local }}/venv UV_PYTHON_INSTALL_DIR={{ uv_local }}/python UV_CACHE_DIR={{ uv_local }}/cache {{ uv_location }}/uv"
 uv_run: "{{ uv_bin }} run --frozen --directory {{ app_code_dir }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-uv_run: "{{ uv_bin }} run --no-sync --directory {{ app_code_dir }}"
+uv_run: "{{ uv_bin }} run --frozen --directory {{ app_code_dir }}"


### PR DESCRIPTION
`uv` seems to expect to be able to write to its cache even when the venv has been created, locked and frozen. Generally speaking, I'm having issues when the venv is created/owned by root.

Thankfully, `uv run` creates it if it doesn't exist and automatically syncs it using the contents of `uv.lock`, so there isn't really any need to sync in the playbook. I've tested this in the dev environment, it works well. The main difference this will make is that the playbook won't fail if the environment can't be installed properly, but the errors will show up in the service's logs and that's not necessarily worse.
