### PR TITLE
Rename variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By default, the pyservice role will create a user, and the following hierarchy:
 # Root for all pyservice-installed applications, owner is root
 /applications        # Variable: {{ pyservice_global_root }}
   # uv binary is installed here
-  /uv                # Variable: {{ uv_location }}
+  /uv                # Variable: {{ pyservice_uv_location }}
   # App directory; owner is the the app user
   /APP_NAME          # Variable: {{ pyservice_root }}
     # Application code and configuration
@@ -56,8 +56,7 @@ Installation proceeds as follows:
   1. Deactivate all services related to the app and delete their files
   2. Clone the repository
   3. Install uv
-  4. Run `uv sync`
-  6. Optionally write files as defined in `pyservice_files`
+  4. Optionally write files as defined in `pyservice_files`
 2. (Do custom setup here)
 3. `activate` tasks
   1. Write the service files and activate them
@@ -80,7 +79,7 @@ The following variables can/must be set in the inventory:
 * `pyservice_repo`: Path to the application repository.
   * If the repo is private, you should set `pyservice_ssh_key` to a private key that is authorized to read the repo (use the SSH URL for the repo), or set `pyservice_ssh_key_path` to the path to the proper file on the host.
 * `pyservice_tag`: Tag or branch of the `pyservice_repo` to checkout.
-* `uv_version`: UV version to use. See the list [here](https://github.com/astral-sh/uv/releases). **Minimum** allowed version should be 0.4.9 (that's the version in which `uv self update {{ uv_version }}` was added).
+* `pyservice_uv_version`: UV version to use. See the list [here](https://github.com/astral-sh/uv/releases). **Minimum** allowed version should be 0.4.9 (that's the version in which `uv self update {{ pyservice_uv_version }}` was added).
 
 
 ## Defining a service
@@ -135,9 +134,9 @@ pyservice_files:
 * `pyservice_dir`: The path on the target system in which to put all the code and configuration. Defaults to `{{ pyservice_root }}/app`
 * `pyservice_config_dir`: The path on the target system in which to put configuration. Defaults to `{{ pyservice_dir }}/config`.
 * `pyservice_config`: Path to the configuration file (defaults to `{{ pyservice_config_dir }}/config.yaml`)
-* `uv_location`: The path where to put the uv binary (defaults to `{{ pyservice_global_root }}/bin`)
-* `uv_isolate`: If true, uv will be put under `pyservice_dir` (defaults to false). It's pointless to change this if you change `uv_location`.
-* `uv_run`: Put that in front of a shell command to run it in the app's environment.
+* `pyservice_uv_location`: The path where to put the uv binary (defaults to `{{ pyservice_global_root }}/bin`)
+* `pyservice_uv_isolate`: If true, uv will be put under `pyservice_dir` (defaults to false). It's pointless to change this if you change `pyservice_uv_location`.
+* `pyservice_run`: Put that in front of a shell command to run it in the app's environment.
 
 
 ## Example playbook

--- a/README.md
+++ b/README.md
@@ -20,31 +20,31 @@ By default, the pyservice role will create a user, and the following hierarchy:
 
 ```bash
 # Root for all pyservice-installed applications, owner is root
-/applications        # Variable: {{ global_app_root }}
+/applications        # Variable: {{ pyservice_global_root }}
   # uv binary is installed here
   /uv                # Variable: {{ uv_location }}
   # App directory; owner is the the app user
-  /APP_NAME          # Variable: {{ app_root }}
+  /APP_NAME          # Variable: {{ pyservice_root }}
     # Application code and configuration
-    /app             # Variable: {{ app_dir }}
+    /app             # Variable: {{ pyservice_dir }}
       # The repository is cloned here
-      /code          # Variable: {{ app_code_dir }}
+      /code          # Variable: {{ pyservice_code_dir }}
       # Configuration files, certificates, keys, etc.
-      /config        # Variable: {{ app_config_dir }}
+      /config        # Variable: {{ pyservice_config_dir }}
         # Default configuration file, provided for convenience but not mandatory
-        config.yaml  # Variable: {{ app_config }}
+        config.yaml  # Variable: {{ pyservice_config }}
     # Application data (anything that must be backed up)
-    /data            # Variable: {{ app_code_dir }}
+    /data            # Variable: {{ pyservice_code_dir }}
     # Virtual environment
     /uv
       /venv
 /etc
   /systemd
     /system
-      # Service files defined in {{ app_services }}
+      # Service files defined in {{ pyservice_services }}
       APP_NAME-xyz.service
       ...
-      # Timer files for recurrent work, defined in {{ app_timers }}
+      # Timer files for recurrent work, defined in {{ pyservice_timers }}
       APP_NAME-uvw.service
       APP_NAME-uvw.timer
       ...
@@ -57,41 +57,41 @@ Installation proceeds as follows:
   2. Clone the repository
   3. Install uv
   4. Run `uv sync`
-  6. Optionally write files as defined in `app_files`
+  6. Optionally write files as defined in `pyservice_files`
 2. (Do custom setup here)
 3. `activate` tasks
   1. Write the service files and activate them
 
 The application's work must be defined in two lists:
 
-* `app_services` for services that must be up at all times, such as a web server or an API
-* `app_timers` for recurrent work, such as scraping information or generating a report every day or week
+* `pyservice_services` for services that must be up at all times, such as a web server or an API
+* `pyservice_timers` for recurrent work, such as scraping information or generating a report every day or week
 
 
 ## Important variables
 
 The following variables can/must be set in the inventory:
 
-* `app_name`: The name of the application.
-* `app_module`: The name of the Python module defined by the application. Defaults to `{{ app_name }}`.
-* `app_user`: The user under which the app should be run and which owns the configuration and data.
-  * Set `app_ensure_user` to `false` in order not to do this, if you want to control user creation.
-* `app_group`: The group to create the various directories under. Defaults to `{{ ansible_common_remote_group | default(app_user) }}`.
-* `app_repo`: Path to the application repository.
-  * If the repo is private, you should set `app_ssh_key` to a private key that is authorized to read the repo (use the SSH URL for the repo), or set `app_ssh_key_path` to the path to the proper file on the host.
-* `app_tag`: Tag or branch of the `app_repo` to checkout.
+* `pyservice_name`: The name of the application.
+* `pyservice_module`: The name of the Python module defined by the application. Defaults to `{{ pyservice_name }}`.
+* `pyservice_user`: The user under which the app should be run and which owns the configuration and data.
+  * Set `pyservice_ensure_user` to `false` in order not to do this, if you want to control user creation.
+* `pyservice_group`: The group to create the various directories under. Defaults to `{{ ansible_common_remote_group | default(pyservice_user) }}`.
+* `pyservice_repo`: Path to the application repository.
+  * If the repo is private, you should set `pyservice_ssh_key` to a private key that is authorized to read the repo (use the SSH URL for the repo), or set `pyservice_ssh_key_path` to the path to the proper file on the host.
+* `pyservice_tag`: Tag or branch of the `pyservice_repo` to checkout.
 * `uv_version`: UV version to use. See the list [here](https://github.com/astral-sh/uv/releases). **Minimum** allowed version should be 0.4.9 (that's the version in which `uv self update {{ uv_version }}` was added).
 
 
 ## Defining a service
 
-The `app_services` variable should contain a list of services. Each service has a name, description and associated command:
+The `pyservice_services` variable should contain a list of services. Each service has a name, description and associated command:
 
 ```yaml
-app_services:
+pyservice_services:
   - name: web
-    description: "Run the web interface for {{ app_name }}"
-    command: python -m {{ app_module }} --config {{ app_config }} web
+    description: "Run the web interface for {{ pyservice_name }}"
+    command: python -m {{ pyservice_module }} --config {{ pyservice_config }} web
 ```
 
 The command is run in the environment created by the role, and it can be anything you want.
@@ -99,14 +99,14 @@ The command is run in the environment created by the role, and it can be anythin
 
 ## Defining a timer
 
-The `app_timers` variable should contain a list of timers. Each timer has a name, description, schedule and associated command:
+The `pyservice_timers` variable should contain a list of timers. Each timer has a name, description, schedule and associated command:
 
 ```yaml
-app_timers:
+pyservice_timers:
   - name: something
     description: "Do something every Monday at 2 AM"
     schedule: "Mon, 02:00"
-    command: python -m {{ app_module }} --config {{ app_config }} do_something
+    command: python -m {{ pyservice_module }} --config {{ pyservice_config }} do_something
 ```
 
 The syntax for the schedule is described [here in section 4.2](https://wiki.archlinux.org/title/systemd/Timers). It ends up in an `OnCalendar` declaration, so you can look at the examples for that.
@@ -119,8 +119,8 @@ The command is run in the environment created by the role, and it can be anythin
 You can easily write files based on content that is in various variables:
 
 ```yaml
-app_files:
-  - dest: "{{ app_config_dir }}/certificate"
+pyservice_files:
+  - dest: "{{ pyservice_config_dir }}/certificate"
     content: "{{ certificate_contents }}"
     mode: "0600"  # default mode is also 0600
 ```
@@ -128,37 +128,37 @@ app_files:
 
 ## Other variables
 
-* `global_app_root`: The path where all applications will be installed into subdirectories (defaults to `/applications`)
-* `app_root`: The path on the target system in which to put all the code, configuration and data. Defaults to `{{ global_app_root }}/{{ app_name }}`
-* `app_code_dir`: Path to the cloned repository.
-* `app_data_dir`: The path on the target system in which to put application data. Defaults to `{{ app_root }}/data`
-* `app_dir`: The path on the target system in which to put all the code and configuration. Defaults to `{{ app_root }}/app`
-* `app_config_dir`: The path on the target system in which to put configuration. Defaults to `{{ app_dir }}/config`.
-* `app_config`: Path to the configuration file (defaults to `{{ app_config_dir }}/config.yaml`)
-* `uv_location`: The path where to put the uv binary (defaults to `{{ global_app_root }}/bin`)
-* `uv_isolate`: If true, uv will be put under `app_dir` (defaults to false). It's pointless to change this if you change `uv_location`.
+* `pyservice_global_root`: The path where all applications will be installed into subdirectories (defaults to `/applications`)
+* `pyservice_root`: The path on the target system in which to put all the code, configuration and data. Defaults to `{{ pyservice_global_root }}/{{ pyservice_name }}`
+* `pyservice_code_dir`: Path to the cloned repository.
+* `pyservice_data_dir`: The path on the target system in which to put application data. Defaults to `{{ pyservice_root }}/data`
+* `pyservice_dir`: The path on the target system in which to put all the code and configuration. Defaults to `{{ pyservice_root }}/app`
+* `pyservice_config_dir`: The path on the target system in which to put configuration. Defaults to `{{ pyservice_dir }}/config`.
+* `pyservice_config`: Path to the configuration file (defaults to `{{ pyservice_config_dir }}/config.yaml`)
+* `uv_location`: The path where to put the uv binary (defaults to `{{ pyservice_global_root }}/bin`)
+* `uv_isolate`: If true, uv will be put under `pyservice_dir` (defaults to false). It's pointless to change this if you change `uv_location`.
 * `uv_run`: Put that in front of a shell command to run it in the app's environment.
 
 
 ## Example playbook
 
-The typical playbook should run the `setup` tasks, then some custom operations, typically templating a configuration file, then run the `activate` tasks. The `app_services`, `app_timers` and `app_files` variables can be defined in the playbook since it makes little sense to change them in the inventory, except possibly for the timer schedules.
+The typical playbook should run the `setup` tasks, then some custom operations, typically templating a configuration file, then run the `activate` tasks. The `pyservice_services`, `pyservice_timers` and `pyservice_files` variables can be defined in the playbook since it makes little sense to change them in the inventory, except possibly for the timer schedules.
 
 ```yaml
 ---
 - hosts: all
   vars:
-    app_services:
+    pyservice_services:
       - name: web
-        description: "Run the web interface for {{ app_name }}"
-        command: python -m {{ app_module }} --config {{ app_config }} web
-    app_timers:
+        description: "Run the web interface for {{ pyservice_name }}"
+        command: python -m {{ pyservice_module }} --config {{ pyservice_config }} web
+    pyservice_timers:
       - name: something
         description: "Do something every Monday at 2 AM"
         schedule: "Mon, 02:00"
-        command: python -m {{ app_module }} --config {{ app_config }} do_something
-    app_files:
-      - dest: "{{ app_config_dir }}/certificate"
+        command: python -m {{ pyservice_module }} --config {{ pyservice_config }} do_something
+    pyservice_files:
+      - dest: "{{ pyservice_config_dir }}/certificate"
         content: "{{ certificate_contents }}"
         mode: "0600"
 
@@ -171,8 +171,8 @@ The typical playbook should run the `setup` tasks, then some custom operations, 
   - name: Template configuration
     ansible.builtin.template:
       src: "config.yaml"
-      dest: "{{ app_config }}"
-      owner: "{{ app_user }}"
+      dest: "{{ pyservice_config }}"
+      owner: "{{ pyservice_user }}"
       mode: "0600"
 
   - name: Activate

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,8 @@ pyservice_code_dir: "{{ pyservice_dir }}/code"
 # pyservice_repo: null   <= must set
 # pyservice_tag: null    <= must set
 
-uv_isolate: false
-uv_version: "0.5.1"
+pyservice_uv_isolate: false
+pyservice_uv_version: "0.5.1"
 
 pyservice_config_dir: "{{ pyservice_dir }}/config"
 pyservice_config: "{{ pyservice_config_dir }}/config.yaml"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,31 +1,31 @@
 ---
-# app_name: null   <= must set
-# app_user: null   <= must set
+# pyservice_name: null   <= must set
+# pyservice_user: null   <= must set
 
-app_ensure_user: true
+pyservice_ensure_user: true
 
-app_group: "{{ ansible_common_remote_group | default(app_user) }}"
+pyservice_group: "{{ ansible_common_remote_group | default(pyservice_user) }}"
 
-global_app_root: "/applications"
-app_root: "{{ global_app_root }}/{{ app_name }}"
-app_module: "{{ app_name }}"
-app_data_dir: "{{ app_root }}/data"
-app_dir: "{{ app_root }}/app"
+pyservice_global_root: "/applications"
+pyservice_root: "{{ pyservice_global_root }}/{{ pyservice_name }}"
+pyservice_module: "{{ pyservice_name }}"
+pyservice_data_dir: "{{ pyservice_root }}/data"
+pyservice_dir: "{{ pyservice_root }}/app"
 
-app_code_dir: "{{ app_dir }}/code"
-# app_repo: null   <= must set
-# app_tag: null    <= must set
+pyservice_code_dir: "{{ pyservice_dir }}/code"
+# pyservice_repo: null   <= must set
+# pyservice_tag: null    <= must set
 
 uv_isolate: false
 uv_version: "0.5.1"
 
-app_config_dir: "{{ app_dir }}/config"
-app_config: "{{ app_config_dir }}/config.yaml"
+pyservice_config_dir: "{{ pyservice_dir }}/config"
+pyservice_config: "{{ pyservice_config_dir }}/config.yaml"
 
-app_files: []
-app_services: []
-app_timers: []
+pyservice_files: []
+pyservice_services: []
+pyservice_timers: []
 
-app_ssh_key: null
-app_ssh_key_default_path: "{{ app_config_dir }}/ssh_key"
-app_ssh_key_path: "{{ (app_ssh_key == None) | ternary(None, app_ssh_key_default_path) }}"
+pyservice_ssh_key: null
+pyservice_ssh_key_default_path: "{{ pyservice_config_dir }}/ssh_key"
+pyservice_ssh_key_path: "{{ (pyservice_ssh_key == None) | ternary(None, pyservice_ssh_key_default_path) }}"

--- a/tasks/activate.yml
+++ b/tasks/activate.yml
@@ -2,20 +2,20 @@
 - name: Fill service definition template
   ansible.builtin.template:
     src: "sustained.service"
-    dest: "/etc/systemd/system/{{ app_name }}-{{ item.name }}.service"
-  loop: "{{ app_services }}"
+    dest: "/etc/systemd/system/{{ pyservice_name }}-{{ item.name }}.service"
+  loop: "{{ pyservice_services }}"
 
 - name: Fill timer unit definition template
   ansible.builtin.template:
     src: "recurrent.service"
-    dest: "/etc/systemd/system/{{ app_name }}-{{ item.name }}.service"
-  loop: "{{ app_timers }}"
+    dest: "/etc/systemd/system/{{ pyservice_name }}-{{ item.name }}.service"
+  loop: "{{ pyservice_timers }}"
 
 - name: Fill timer definition template
   ansible.builtin.template:
     src: "recurrent.timer"
-    dest: "/etc/systemd/system/{{ app_name }}-{{ item.name }}.timer"
-  loop: "{{ app_timers }}"
+    dest: "/etc/systemd/system/{{ pyservice_name }}-{{ item.name }}.timer"
+  loop: "{{ pyservice_timers }}"
 
 - name: Reload daemon
   become: true
@@ -25,15 +25,15 @@
 - name: Restart services
   become: true
   ansible.builtin.systemd:
-    name: "{{ app_name }}-{{ item.name }}.service"
+    name: "{{ pyservice_name }}-{{ item.name }}.service"
     state: restarted
   loop:
-    "{{ app_services }}"
+    "{{ pyservice_services }}"
 
 - name: Enable timers
   become: true
   ansible.builtin.systemd:
-    name: "{{ app_name }}-{{ item.name }}.timer"
+    name: "{{ pyservice_name }}-{{ item.name }}.timer"
     state: restarted
   loop:
-    "{{ app_timers }}"
+    "{{ pyservice_timers }}"

--- a/tasks/clear.yml
+++ b/tasks/clear.yml
@@ -1,5 +1,5 @@
 ---
 - name: Clear out the app
   ansible.builtin.file:
-    path: "{{ app_dir }}"
+    path: "{{ pyservice_dir }}"
     state: absent

--- a/tasks/copy-files.yml
+++ b/tasks/copy-files.yml
@@ -3,11 +3,11 @@
   ansible.builtin.file:
     path: "{{ item.dest | dirname }}"
     state: directory
-    owner: "{{ app_user }}"
-    group: "{{ app_group }}"
+    owner: "{{ pyservice_user }}"
+    group: "{{ pyservice_group }}"
     mode: "0700"
   when: "item.content != None"
-  loop: "{{ app_files }}"
+  loop: "{{ pyservice_files }}"
   loop_control:
     label: "{{ item.dest }}"
 
@@ -15,11 +15,11 @@
   ansible.builtin.copy:
     content: "{{ item.content }}"
     dest: "{{ item.dest }}"
-    owner: "{{ app_user }}"
-    group: "{{ app_group }}"
+    owner: "{{ pyservice_user }}"
+    group: "{{ pyservice_group }}"
     mode: "{{ item.mode | default('0600') }}"
   when: "item.content != None"
-  loop: "{{ app_files }}"
+  loop: "{{ pyservice_files }}"
   loop_control:
     label: "{{ item.dest }}"
   no_log: true

--- a/tasks/deactivate.yml
+++ b/tasks/deactivate.yml
@@ -1,11 +1,11 @@
 ---
 - name: List services
-  register: app_services_existing
+  register: pyservice_services_existing
   ansible.builtin.find:
     paths:
       - "/etc/systemd/system"
     pattern:
-      - "{{ app_name }}-*"
+      - "{{ pyservice_name }}-*"
 
 - name: Pause and disable services
   ansible.builtin.systemd:
@@ -13,7 +13,7 @@
     enabled: false
     state: stopped
   loop:
-    "{{ app_services_existing.files }}"
+    "{{ pyservice_services_existing.files }}"
   loop_control:
     label: "{{ item.path | basename }}"
 
@@ -21,6 +21,6 @@
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: absent
-  loop: "{{ app_services_existing.files }}"
+  loop: "{{ pyservice_services_existing.files }}"
   loop_control:
     label: "{{ item.path }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,13 +7,13 @@
     state: present
 
 - name: Install uv
-  ansible.builtin.script: install-uv.sh {{ uv_location }} {{ uv_version }}
+  ansible.builtin.script: install-uv.sh {{ pyservice_uv_location }} {{ pyservice_uv_version }}
   args:
-    creates: "{{ uv_location }}/uv"
+    creates: "{{ pyservice_uv_location }}/uv"
 
 - name: Set up correct uv version
   ansible.builtin.command:
-    cmd: "{{ uv_bin }} self update {{ uv_version }}"
+    cmd: "{{ pyservice_uv_bin }} self update {{ pyservice_uv_version }}"
 
 - name: Copy SSH key
   when: "pyservice_ssh_key"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,18 +16,18 @@
     cmd: "{{ uv_bin }} self update {{ uv_version }}"
 
 - name: Copy SSH key
-  when: "app_ssh_key"
+  when: "pyservice_ssh_key"
   ansible.builtin.copy:
-    content: "{{ app_ssh_key }}"
-    dest: "{{ app_ssh_key_path }}"
-    owner: "{{ app_user }}"
+    content: "{{ pyservice_ssh_key }}"
+    dest: "{{ pyservice_ssh_key_path }}"
+    owner: "{{ pyservice_user }}"
     mode: "0600"
   no_log: true
 
 - name: Checkout the code
   ansible.builtin.git:
-    repo: "{{ app_repo }}"
-    dest: "{{ app_code_dir }}"
-    version: "{{ app_tag }}"
+    repo: "{{ pyservice_repo }}"
+    dest: "{{ pyservice_code_dir }}"
+    version: "{{ pyservice_tag }}"
     accept_hostkey: yes
-    key_file: "{{ app_ssh_key_path }}"
+    key_file: "{{ pyservice_ssh_key_path }}"

--- a/tasks/structure.yml
+++ b/tasks/structure.yml
@@ -1,47 +1,47 @@
 ---
 - name: Ensure user
   become: true
-  when: app_ensure_user
+  when: pyservice_ensure_user
   ansible.builtin.user:
-    name: "{{ app_user }}"
-    comment: "User for {{ app_name }} service"
+    name: "{{ pyservice_user }}"
+    comment: "User for {{ pyservice_name }} service"
 
 - name: Ensure group
   become: true
-  when: "app_ensure_user and app_group != app_user"
+  when: "pyservice_ensure_user and pyservice_group != pyservice_user"
   ansible.builtin.user:
-    name: "{{ app_user }}"
+    name: "{{ pyservice_user }}"
     groups:
-    - "{{ app_group }}"
+    - "{{ pyservice_group }}"
 
 - name: Create the app directory
   ansible.builtin.file:
-    path: "{{ app_root }}"
+    path: "{{ pyservice_root }}"
     state: directory
     mode: "0775"
-    owner: "{{ app_user }}"
-    group: "{{ app_group }}"
+    owner: "{{ pyservice_user }}"
+    group: "{{ pyservice_group }}"
 
 - name: Create the data directory
   ansible.builtin.file:
-    path: "{{ app_data_dir }}"
+    path: "{{ pyservice_data_dir }}"
     state: directory
     mode: "0750"
-    owner: "{{ app_user }}"
-    group: "{{ app_group }}"
+    owner: "{{ pyservice_user }}"
+    group: "{{ pyservice_group }}"
 
 - name: Create the app directory
   ansible.builtin.file:
-    path: "{{ app_dir }}"
+    path: "{{ pyservice_dir }}"
     state: directory
     mode: "0775"
-    owner: "{{ app_user }}"
-    group: "{{ app_group }}"
+    owner: "{{ pyservice_user }}"
+    group: "{{ pyservice_group }}"
 
 - name: Create the config directory
   ansible.builtin.file:
-    path: "{{ app_config_dir }}"
+    path: "{{ pyservice_config_dir }}"
     state: directory
     mode: "0750"
-    owner: "{{ app_user }}"
-    group: "{{ app_group }}"
+    owner: "{{ pyservice_user }}"
+    group: "{{ pyservice_group }}"

--- a/templates/recurrent.service
+++ b/templates/recurrent.service
@@ -2,7 +2,7 @@
 Description="{{ item.description }}"
 
 [Service]
-User={{ app_user }}
+User={{ pyservice_user }}
 Type=simple
 ExecStart={{ uv_run }} {{ item.command }}
 

--- a/templates/recurrent.service
+++ b/templates/recurrent.service
@@ -4,7 +4,7 @@ Description="{{ item.description }}"
 [Service]
 User={{ pyservice_user }}
 Type=simple
-ExecStart={{ uv_run }} {{ item.command }}
+ExecStart={{ pyservice_run }} {{ item.command }}
 
 [Install]
 WantedBy=multi-user.agent

--- a/templates/recurrent.timer
+++ b/templates/recurrent.timer
@@ -4,7 +4,7 @@ Description="{{ item.description }} (Timer)"
 [Timer]
 OnCalendar={{ item.schedule }}
 Persistent=True
-Unit={{ app_name }}-{{ item.name }}.service
+Unit={{ pyservice_name }}-{{ item.name }}.service
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/sustained.service
+++ b/templates/sustained.service
@@ -3,7 +3,7 @@ Description="{{ item.description }}"
 After=network.target
 
 [Service]
-User={{ app_user }}
+User={{ pyservice_user }}
 Type=simple
 ExecStart={{ uv_run }} {{ item.command }}
 Restart=always

--- a/templates/sustained.service
+++ b/templates/sustained.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ pyservice_user }}
 Type=simple
-ExecStart={{ uv_run }} {{ item.command }}
+ExecStart={{ pyservice_run }} {{ item.command }}
 Restart=always
 
 [Install]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-uv_location: "{{ app_dir if uv_isolate else global_app_root }}/uv"
-uv_local: "{{ app_dir }}/uv"
+uv_location: "{{ pyservice_dir if uv_isolate else pyservice_global_root }}/uv"
+uv_local: "{{ pyservice_dir }}/uv"
 uv_bin: "env UV_PROJECT_ENVIRONMENT={{ uv_local }}/venv UV_PYTHON_INSTALL_DIR={{ uv_local }}/python UV_CACHE_DIR={{ uv_local }}/cache {{ uv_location }}/uv"
-uv_run: "{{ uv_bin }} run --frozen --directory {{ app_code_dir }}"
+uv_run: "{{ uv_bin }} run --frozen --directory {{ pyservice_code_dir }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-uv_location: "{{ pyservice_dir if uv_isolate else pyservice_global_root }}/uv"
-uv_local: "{{ pyservice_dir }}/uv"
-uv_bin: "env UV_PROJECT_ENVIRONMENT={{ uv_local }}/venv UV_PYTHON_INSTALL_DIR={{ uv_local }}/python UV_CACHE_DIR={{ uv_local }}/cache {{ uv_location }}/uv"
-uv_run: "{{ uv_bin }} run --frozen --directory {{ pyservice_code_dir }}"
+pyservice_uv_local: "{{ pyservice_dir }}/uv"
+pyservice_uv_location: "{{ pyservice_uv_local if pyservice_uv_isolate else pyservice_global_root }}/uv"
+pyservice_uv_bin: "env UV_PROJECT_ENVIRONMENT={{ pyservice_uv_local }}/venv UV_PYTHON_INSTALL_DIR={{ pyservice_uv_local }}/python UV_CACHE_DIR={{ pyservice_uv_local }}/cache {{ pyservice_uv_location }}/uv"
+pyservice_run: "{{ pyservice_uv_bin }} run --frozen --directory {{ pyservice_code_dir }}"


### PR DESCRIPTION
Rename variables from `app_XXX` to `pyservice_XXX` to improve readability and greppability in the inventory that sets that role's variables.
